### PR TITLE
feat: add mainConfig to set global configuration from outside of app theme

### DIFF
--- a/example/lib/home_screen.dart
+++ b/example/lib/home_screen.dart
@@ -125,10 +125,10 @@ class Screen1 extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('fkfk'),
+        title: Text('Screen 1'),
       ),
       body: Column(
-        children: [Text('fkkfkf')],
+        children: [Text('Hello from Screen 1')],
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:main_text_field/main_text_field.dart';
 import 'package:main_widgets/main_widgets.dart';
 import 'package:smart_localize/smart_localize.dart';
 
@@ -18,22 +19,25 @@ class MyApp extends StatelessWidget {
       designSize: const Size(375, 812),
       minTextAdapt: true,
     );
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      supportedLocales: const [
-        Locale('en'),
-        Locale('ar'),
-      ],
-      locale: const Locale('ar'),
-      localeResolutionCallback: (locale, supportedLocales) =>
-          locale ?? const Locale('ar'),
-      localizationsDelegates: context.smartLocalizeDelegates,
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
+    return MainTextFiledConfigProvider(
+      config: const ConfigModel(defaultWidth: 250, defaultHeight: 50),
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        supportedLocales: const [
+          Locale('en'),
+          Locale('ar'),
+        ],
+        locale: const Locale('ar'),
+        localeResolutionCallback: (locale, supportedLocales) =>
+            locale ?? const Locale('ar'),
+        localizationsDelegates: context.smartLocalizeDelegates,
+        title: 'Flutter Demo',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+          useMaterial3: true,
+        ),
+        home: const HomeScreen(),
       ),
-      home: const HomeScreen(),
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -246,7 +246,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.16"
+    version: "0.0.18"
   main_widgets:
     dependency: "direct main"
     description:

--- a/lib/main_text_field.dart
+++ b/lib/main_text_field.dart
@@ -1,5 +1,6 @@
 library;
 
+export 'src/config/main_config.dart';
 export 'src/functions/get_input_decoration.dart';
 export 'src/functions/validation_functions.dart';
 export 'src/main_text_field.dart';

--- a/lib/src/config/config_model.dart
+++ b/lib/src/config/config_model.dart
@@ -1,0 +1,9 @@
+class ConfigModel {
+  final double defaultWidth;
+  final double defaultHeight;
+
+  const ConfigModel({
+    required this.defaultWidth,
+    required this.defaultHeight,
+  });
+}

--- a/lib/src/config/main_config.dart
+++ b/lib/src/config/main_config.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+import 'config_model.dart';
+
+export 'config_model.dart';
+
+class MainTextFiledConfigProvider extends InheritedWidget {
+  final ConfigModel config;
+
+  const MainTextFiledConfigProvider({
+    super.key,
+    required this.config,
+    required super.child,
+  });
+
+  static ConfigModel of(BuildContext context) {
+    return context
+            .dependOnInheritedWidgetOfExactType<MainTextFiledConfigProvider>()
+            ?.config ??
+        const ConfigModel(defaultWidth: 370, defaultHeight: 50);
+  }
+
+  @override
+  bool updateShouldNotify(MainTextFiledConfigProvider oldWidget) {
+    return config != oldWidget.config;
+  }
+}

--- a/lib/src/main_text_field.dart
+++ b/lib/src/main_text_field.dart
@@ -347,7 +347,7 @@ class MainTextField extends StatefulWidget {
   factory MainTextField.confirmPassword({
     TextStyle? titleStyle,
     bool showPrefixIcon = false,
-    double maxWidth = 370,
+    double? maxWidth,
     bool readOnly = false,
     bool isRequired = true,
     bool hideAsterisk = false,
@@ -423,7 +423,7 @@ class MainTextField extends StatefulWidget {
   }
 
   factory MainTextField.number({
-    double maxWidth = 370,
+    double? maxWidth,
     bool readOnly = false,
     double spaceBetween = 4,
     bool isRequired = true,
@@ -496,7 +496,7 @@ class MainTextField extends StatefulWidget {
   }
 
   factory MainTextField.phone({
-    double maxWidth = 370,
+    double? maxWidth,
     double spaceBetween = 4,
     bool showPrefixIcon = false,
     String initialCountryCode = '+20',
@@ -587,8 +587,11 @@ class MainTextField extends StatefulWidget {
 class _MainTextFieldState extends State<MainTextField> {
   @override
   Widget build(BuildContext context) {
+    final config = MainTextFiledConfigProvider.of(context);
+
     return ConstrainedBox(
-      constraints: BoxConstraints(maxWidth: widget.maxWidth ?? 370),
+      constraints:
+          BoxConstraints(maxWidth: widget.maxWidth ?? config.defaultWidth),
       child: Column(
         children: [
           if (widget.title != null)


### PR DESCRIPTION
- provide a global configuration `MainTextFiledConfigProvider`.
- all configuration can be added in the `ConfigModel` class.